### PR TITLE
feat(image): CLIP-based item image embeddings with caching & retries

### DIFF
--- a/scripts/build_image_emb.py
+++ b/scripts/build_image_emb.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+# Build item IMAGE embeddings (CLIP) with caching & retries.
+# Input:  data/processed/<dataset>/items_with_meta.parquet  (must have: item_id, image_url)
+# Output: data/processed/<dataset>/item_image_emb.parquet  (item_id, vector)
+
+from __future__ import annotations
+import argparse
+import time
+from pathlib import Path
+from typing import List
+
+import numpy as np
+import pandas as pd
+from tqdm import tqdm
+
+from src.models.image_encoder import ImageEncoder
+from src.utils.paths import get_dataset_paths, ensure_dir
+
+
+def _download_to_cache(urls: List[str], cache_dir: Path, retries: int = 2, sleep: float = 0.5) -> List[Path]:
+    """
+    Download URLs to cache dir. Returns list of file paths (may be missing if failed).
+    We keep filenames as sequential indices for simplicity.
+    """
+    from PIL import Image
+    import requests
+    import io
+
+    cache_dir = ensure_dir(cache_dir)
+    out_paths: List[Path] = []
+    for i, url in enumerate(tqdm(urls, desc="Downloading")):
+        fp = cache_dir / f"{i:06d}.jpg"
+        if fp.exists() and fp.stat().st_size > 0:
+            out_paths.append(fp)
+            continue
+
+        ok = False
+        for _ in range(retries + 1):
+            try:
+                if not url or not isinstance(url, str):
+                    break
+                r = requests.get(url, timeout=10, stream=True)
+                r.raise_for_status()
+                img = Image.open(io.BytesIO(r.content)).convert("RGB")
+                img.save(fp, format="JPEG", quality=90, optimize=True)
+                ok = True
+                break
+            except Exception:
+                time.sleep(sleep)
+                continue
+        if not ok:
+            # create empty placeholder so indexing stays aligned
+            if not fp.exists():
+                fp.touch()
+        out_paths.append(fp)
+    return out_paths
+
+
+def _load_pils(filepaths: List[Path]):
+    """Load PIL images from cached files (None for failures)."""
+    from PIL import Image, UnidentifiedImageError
+    pils = []
+    for fp in filepaths:
+        try:
+            img = Image.open(fp).convert("RGB")
+            pils.append(img)
+        except (FileNotFoundError, UnidentifiedImageError, OSError, ValueError):
+            pils.append(None)
+    return pils
+
+
+def main(dataset: str, batch_size: int, model_name: str, pretrained: str):
+    paths = get_dataset_paths(dataset)
+    proc_dir = ensure_dir(paths["processed"])
+
+    items_fp = proc_dir / "items_with_meta.parquet"
+    if not items_fp.exists():
+        raise FileNotFoundError(f"Missing {items_fp}. Run scripts/join_meta.py first.")
+
+    items = pd.read_parquet(items_fp)
+    if "item_id" not in items.columns or "image_url" not in items.columns:
+        raise ValueError("items_with_meta.parquet must have columns: item_id, image_url")
+
+    item_ids = items["item_id"].tolist()
+    urls = items["image_url"].fillna("").astype(str).tolist()
+
+    cache_dir = Path("data/cache/images") / dataset
+    filepaths = _download_to_cache(urls, cache_dir=cache_dir)
+
+    pils = _load_pils(filepaths)
+    ok_mask = [im is not None for im in pils]
+    cov = float(np.mean(ok_mask))
+    print(f"🖼️ Cached images: {sum(ok_mask)}/{len(ok_mask)} ({cov:.1%})")
+
+    # Encode
+    enc = ImageEncoder(model_name=model_name, pretrained=pretrained)
+    # replace None with white blank to keep shape; encode_pils will handle
+    from PIL import Image
+    blank = Image.new("RGB", (224, 224), color=(255, 255, 255))
+    safe_pils = [im if im is not None else blank for im in pils]
+
+    vecs = enc.encode_pils(safe_pils, batch_size=batch_size, desc="CLIP encode")
+    # zero-out failed ones (keep row count stable)
+    vecs[np.logical_not(ok_mask)] = 0.0
+
+    out = pd.DataFrame({"item_id": item_ids, "vector": [v.astype(np.float32) for v in vecs]})
+    out_fp = proc_dir / "item_image_emb.parquet"
+    out.to_parquet(out_fp, index=False)
+    print(f"✅ Saved image vectors → {out_fp}  (dim={vecs.shape[1] if len(vecs) else 0})")
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--dataset", required=True, help="dataset key (e.g., beauty)")
+    ap.add_argument("--batch_size", type=int, default=64)
+    ap.add_argument("--model", default="ViT-B-32")
+    ap.add_argument("--pretrained", default="laion2b_s34b_b79k")
+    args = ap.parse_args()
+
+    main(args.dataset, args.batch_size, args.model, args.pretrained)

--- a/src/models/image_encoder.py
+++ b/src/models/image_encoder.py
@@ -1,0 +1,117 @@
+# src/models/image_encoder.py
+from __future__ import annotations
+from typing import List, Optional, Tuple
+from pathlib import Path
+import io
+import requests
+from PIL import Image, UnidentifiedImageError
+
+import torch
+import numpy as np
+from tqdm import tqdm
+import open_clip  # pip install open-clip-torch
+
+
+class ImageEncoder:
+    """
+    Thin wrapper around OpenCLIP for image embeddings.
+      - Model: ViT-B/32 (laion2b_s34b_b79k) by default (fast & lightweight)
+      - GPU if available
+      - Takes PIL Image or URL strings
+      - Returns L2-normalized float32 numpy vectors
+    """
+
+    def __init__(
+        self,
+        model_name: str = "ViT-B-32",
+        pretrained: str = "laion2b_s34b_b79k",
+        device: Optional[str] = None,
+    ):
+        self.device = device or ("cuda" if torch.cuda.is_available() else "cpu")
+        self.model, _, self.preprocess = open_clip.create_model_and_transforms(
+            model_name, pretrained=pretrained, device=self.device
+        )
+        self.model.eval()
+
+    @property
+    def dim(self) -> int:
+        return self.model.visual.output_dims
+
+    # -------------------- image IO helpers -------------------- #
+    @staticmethod
+    def _read_image_from_url(url: str, timeout: float = 10.0) -> Optional[Image.Image]:
+        try:
+            r = requests.get(url, timeout=timeout, stream=True)
+            r.raise_for_status()
+            img = Image.open(io.BytesIO(r.content)).convert("RGB")
+            return img
+        except Exception:
+            return None
+
+    @staticmethod
+    def _read_image_from_path(path: Path) -> Optional[Image.Image]:
+        try:
+            img = Image.open(path).convert("RGB")
+            return img
+        except (FileNotFoundError, UnidentifiedImageError, OSError):
+            return None
+
+    # -------------------- main encode API -------------------- #
+    def encode_pils(self, images: List[Image.Image], batch_size: int = 64, desc: str = "Encoding") -> np.ndarray:
+        """Encode a list of PIL images."""
+        if len(images) == 0:
+            return np.zeros((0, self.dim), dtype=np.float32)
+
+        vecs = []
+        for i in tqdm(range(0, len(images), batch_size), desc=desc):
+            chunk = images[i : i + batch_size]
+            tensors = torch.stack([self.preprocess(img) for img in chunk]).to(self.device)
+            with torch.no_grad(), torch.cuda.amp.autocast(enabled=(self.device == "cuda")):
+                feats = self.model.encode_image(tensors)
+                feats = feats / feats.norm(dim=-1, keepdim=True)
+            vecs.append(feats.detach().cpu().numpy().astype(np.float32))
+        return np.vstack(vecs)
+
+    def encode_urls(
+        self,
+        urls: List[str],
+        batch_size: int = 64,
+        cache_dir: Optional[Path] = None,
+        desc: str = "Encoding",
+        timeout: float = 10.0,
+    ) -> Tuple[np.ndarray, List[bool]]:
+        """
+        Encode images from URLs. Optionally cache to disk.
+        Returns:
+          - ndarray [N, D]
+          - list[bool] whether entry was successfully encoded
+        """
+        pils: List[Optional[Image.Image]] = []
+        ok: List[bool] = []
+        cache_dir = Path(cache_dir) if cache_dir else None
+        if cache_dir:
+            cache_dir.mkdir(parents=True, exist_ok=True)
+
+        for url in tqdm(urls, desc="Fetching"):
+            img = None
+            # cache hit?
+            if cache_dir and url:
+                # hash filename by simple replace (urls may be long)
+                # or just store as numbered files in caller
+                pass
+            if url:
+                img = self._read_image_from_url(url, timeout=timeout)
+
+            pils.append(img if img is not None else None)
+            ok.append(img is not None)
+
+        # Replace None with a tiny blank image to keep shape; will be masked out
+        blank = Image.new("RGB", (224, 224), color=(255, 255, 255))
+        safe_pils = [im if im is not None else blank for im in pils]
+        vecs = self.encode_pils(safe_pils, batch_size=batch_size, desc=desc)
+
+        # Zero-out failed rows so we can mask downstream
+        if not all(ok):
+            mask = np.array(ok, dtype=bool)
+            vecs[~mask] = 0.0
+        return vecs, ok


### PR DESCRIPTION
This PR adds the image embedding pipeline for the Beauty dataset:
	•	Implemented image_encoder.py using OpenCLIP (ViT-B/32) to extract 512-dim image embeddings.
	•	Added build_image_emb.py script to download/cache images, handle retries, and generate embeddings.
	•	Saves output to data/processed/<dataset>/item_image_emb.parquet.
	•	Handles missing images with zero vectors (preserves item alignment).
	•	Verified 58/85 items have valid image vectors for Beauty dataset.

Next steps (future PRs):
	•	Integrate image embeddings into multimodal retrieval.
	•	Perform image-only and multimodal evaluation.
